### PR TITLE
Add shutdown support

### DIFF
--- a/lsp/shutdown.go
+++ b/lsp/shutdown.go
@@ -1,0 +1,21 @@
+package lsp
+
+type ShutdownRequest struct {
+	Request
+}
+
+type ShutdownResponse struct {
+	Response
+
+	// Must be null.
+	Result *int `json:"result"`
+}
+
+func NewShutdownResponse(id int) ShutdownResponse {
+	return ShutdownResponse{
+		Response: Response{
+			RPC: "2.0",
+			ID:  &id,
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,17 @@ func handleMessage(logger *log.Logger, writer io.Writer, state state.State, meth
 		writeResponse(writer, msg)
 
 		logger.Print("Sent the reply")
+	case "shutdown":
+		var request lsp.ShutdownRequest
+		if err := json.Unmarshal(contents, &request); err != nil {
+			logger.Printf("shutdown: %s", err)
+		}
+
+		// sent shutdown response
+		msg := lsp.NewShutdownResponse(request.ID)
+		writeResponse(writer, msg)
+
+		logger.Print("Shutdown")
 	case "textDocument/didOpen":
 		var request lsp.DidOpenTextDocumentNotification
 		if err := json.Unmarshal(contents, &request); err != nil {


### PR DESCRIPTION
The helix editor's LSP client doesn't terminate until it receives a response to a shutdown request from the server. Instead, it hangs until the timeout expires, and then exits with the "Timed out waiting for language servers to shutdown" error